### PR TITLE
fix(main-file): fix typo ion package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@solx/css-features",
   "version": "0.0.0-development",
   "description": "'Typescriptification of css-media-features package",
-  "main": ".dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/*"


### PR DESCRIPTION
there was a typo in package json, which made this an unusable package

fix #2